### PR TITLE
ci(publish): filter out drafts and prereleases from version set

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,9 +60,15 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          # Get last N release tags
+          # Get last N release tags. Filter out drafts and prereleases:
+          # the releases API returns drafts when the token has push
+          # access, and a stale orphan draft (or an rc tag pushed for
+          # CI testing) shouldn't be processed by production — its
+          # old-key signatures or unpublished assets will fail
+          # "Verify All Assets" and wedge the run.
           VERSIONS=$(gh api repos/dotsecenv/dotsecenv/releases \
-            --jq '.[].tag_name' | head -n ${{ env.KEEP_VERSIONS }})
+            --jq '.[] | select(.draft|not) | select(.prerelease|not) | .tag_name' \
+            | head -n ${{ env.KEEP_VERSIONS }})
 
           echo "versions<<EOF" >> $GITHUB_OUTPUT
           echo "$VERSIONS" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

`Get Release Versions` calls `gh api repos/dotsecenv/dotsecenv/releases` and walks the result. The API returns **draft releases** when the calling token has push access, so an orphan draft (left over from a long-ago CI rc tag that was never cleaned up) ends up in the version list. The publish workflow then downloads its assets and tries to verify the signature — against whichever key signed the assets at the time, which for old orphans may be a key that's been rotated since.

That's exactly what wedged the publish flow after the recent release-key rotation:

- v0.0.0-rc1 was a draft release signed by the **old** release key
- The new release key was rotated in
- "Verify All Assets" tried to verify rc1's signature against the new key → ❌ Can't check signature: No public key
- The whole workflow aborted before deploying the updated key.asc to GH Pages
- `get.dotsecenv.com/key.asc` stayed on the old key → trigger-action-e2e on `dotsecenv/dotsecenv` also broke (couldn't verify new release artifacts)

The fix: filter the API output by `.draft|not` AND `.prerelease|not`. Only **published, non-prerelease** tags make it into the version set. A future rc tag wouldn't wedge production either.

## Test plan

- [ ] After merge, dispatch the workflow manually (`gh workflow run publish.yml -R dotsecenv/packages`) or wait for the next monorepo release to fire `repository_dispatch: publish-packages`.
- [ ] Confirm "Get Release Versions" output no longer contains `v0.0.0-rc1` (or any future draft/prerelease).
- [ ] Confirm "Verify All Assets" passes for every version it does process.
- [ ] Confirm `curl -fsSL https://get.dotsecenv.com/key.asc | gpg --show-keys` returns both old + new keys after the deploy completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)