### PR TITLE
ci(publish): migrate actions/create-github-app-token to client-id

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: dotsecenv
@@ -261,7 +261,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: dotsecenv


### PR DESCRIPTION
## Summary

Suppresses the deprecation warning emitted on every publish run:

\`\`\`
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
\`\`\`

Both \`actions/create-github-app-token@v3\` invocations in \`publish.yml\` now use \`client-id: \${{ vars.RELEASE_APP_CLIENT_ID }}\` instead of \`app-id: \${{ vars.RELEASE_APP_ID }}\`. The matching variable is already set on the org from the same migration just done on \`dotsecenv/dotsecenv\`.

## Test plan

- [ ] After merge, the next \`repository_dispatch: publish-packages\` (or a manual \`gh workflow run publish.yml\`) shows no deprecation warning on either token-mint step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)