### PR TITLE
fix(publish): copy key.asc from repo instead of regenerating from imported signing key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -224,7 +224,14 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           LATEST: ${{ steps.versions.outputs.latest }}
         run: |
-          gpg --armor --export "${{ steps.import_gpg.outputs.keyid }}" > _stage/key.asc
+          # key.asc in this repo is the canonical bundle of public keys
+          # users need to verify ANY release (current + previous keys
+          # concatenated). Copy it as-is so prior signatures stay
+          # verifiable across key rotations.
+          # We deliberately do NOT regenerate via `gpg --armor --export`:
+          # that exports only the currently-imported signing key and
+          # would strip retired keys from the deployed bundle.
+          cp key.asc _stage/key.asc
           cp README.md _stage/
           cp CNAME _stage/
 


### PR DESCRIPTION
## Summary

\`gpg --armor --export <imported signing keyid>\` only exports the **currently active** signing key. After the recent key rotation, this overwrote the repo's dual-key \`key.asc\` (which has both the new and old public keys concatenated) with a single-key bundle.

Net effect: \`get.dotsecenv.com/key.asc\` was being served with **only the new key**, so:
- Verifying signatures on releases prior to the rotation → ❌ \"No public key\" (old key missing)
- Briefly during deploy propagation, verifying the new key → ❌ also \"No public key\" (cache served the empty old version)

That's the second-order cause of \`trigger-action-e2e\` failures on the monorepo even after #17 unwedged the publish workflow.

Fix: just \`cp key.asc _stage/key.asc\`. The static file in this repo is the canonical bundle — current + retired keys concatenated.

## Future rotations

When rotating the release-signing key:
1. Generate the new key (\`scripts/generate_release_key.sh\` on dotsecenv/dotsecenv)
2. **Prepend** (or append) the new public key to \`key.asc\` in this repo
3. PR it here
4. After merge, the next publish run deploys the dual-key bundle to GH Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)